### PR TITLE
🔖 Prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.0 (2023-07-27)
+
 Features:
 
 - Set the default HTTP healthcheck to `/health` and expose the `healthcheck_endpoint` variable.


### PR DESCRIPTION
Features:

- Set the default HTTP healthcheck to `/health` and expose the `healthcheck_endpoint` variable.

### Commits

- 📝 Update changelog