### PR TITLE
✨ `spanner_ddl_dependency` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Features:
+
+- Define the `spanner_ddl_dependency` variable to facilitate expressing dependency on a Spanner database.
+
+Fixes:
+
+- Set missing project ID in Cloud Run permissions.
+
 ## v0.2.0 (2023-07-27)
 
 Features:

--- a/pubsub-triggers.tf
+++ b/pubsub-triggers.tf
@@ -44,6 +44,7 @@ resource "google_service_account" "pubsub_trigger_invoker" {
 resource "google_cloud_run_service_iam_member" "pubsub_trigger_invoker" {
   count = length(local.pubsub_triggers) > 0 ? 1 : 0
 
+  project  = local.gcp_project_id
   service  = google_cloud_run_service.service.name
   location = google_cloud_run_service.service.location
   role     = "roles/run.invoker"

--- a/service.tf
+++ b/service.tf
@@ -120,6 +120,7 @@ resource "google_cloud_run_service" "service" {
   }
 
   depends_on = [
+    var.spanner_ddl_dependency,
     google_spanner_database_iam_member.service_spanner,
     google_pubsub_topic_iam_member.service_pubsub_publisher,
     google_project_iam_member.service_firestore_user,

--- a/variables.tf
+++ b/variables.tf
@@ -158,3 +158,9 @@ variable "enable_pubsub_triggers" {
   description = "Whether Pub/Sub triggers for the service should be configured. Defaults to `enable_triggers`."
   default     = null
 }
+
+variable "spanner_ddl_dependency" {
+  type        = list(string)
+  description = "The DDL for the (Spanner) database that the service depends on. This is used to ensure that the database is created and updated before the service is deployed."
+  default     = []
+}


### PR DESCRIPTION
This PR introduces the `spanner_ddl_dependency` variable, which allows expressing a dependency on a Spanner database. Using this mechanism, it is not necessary to use a module-wide `depends_on` on the Spanner database.

### Commits

- 🐛 Set missing project ID
- ✨ Define the spanner_ddl_dependency variable
- 📝 Update changelog