### PR TITLE
🐛 Simplify Pub/Sub topics dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Simplify `pubsub_topic_ids` expression to allow Terraform to detect minimal dependencies.
+
 ## v0.4.0 (2023-08-01)
 
 Breaking changes:

--- a/pubsub.tf
+++ b/pubsub.tf
@@ -6,13 +6,11 @@ locals {
     [for trigger in values(local.pubsub_triggers) : trigger.topic],
   )
 
-  # The map between event full names and Pub/Sub topic IDs, only for referenced topics.
-  # This defaults to topics in the set GCP project, but can be overridden by the user.
-  pubsub_topic_ids = {
-    for topic in local.referenced_topics :
-    topic => coalesce(
-      try(var.pubsub_topic_ids[topic], null),
-      "projects/${local.gcp_project_id}/topics/${topic}"
-    )
-  }
+  # The map between event full names and Pub/Sub topic IDs.
+  # This defaults to topics in the set GCP project, but can be overridden by the user (especially usefull to express the
+  # dependency on the Pub/Sub topic resources).
+  pubsub_topic_ids = merge(
+    { for topic in local.referenced_topics : topic => "projects/${local.gcp_project_id}/topics/${topic}" },
+    var.pubsub_topic_ids,
+  )
 }


### PR DESCRIPTION
This PR changes the way `local.pubsub_topic_ids` is expressed such that Terraform can still track topic-wise dependencies. With the previous expression, Terraform would lose track of the specific dependencies, and changes to the Pub/Sub subscriptions and Cloud Run service would be detected any time the input `var.pubsub_topic_ids` map would change.

### Commits

- 🐛 Simplify pubsub_topic_ids expression to allow Terraform to detect minimal dependencies
- 📝 Update changelog