### PR TITLE
🔖 Prepare v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.1 (2023-08-25)
+
 Fixes:
 
 - Simplify `pubsub_topic_ids` expression to allow Terraform to detect minimal dependencies.


### PR DESCRIPTION
Fixes:

- Simplify `pubsub_topic_ids` expression to allow Terraform to detect minimal dependencies.

### Commits

- 📝 Update changelog