### PR TITLE
🐛 Explicit Spanner permission dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Ensure IAM permissions for Spanner depend on the databases (the `spanner_ddl_dependency` variable).
+
 ## v0.4.1 (2023-08-25)
 
 Fixes:

--- a/spanner.tf
+++ b/spanner.tf
@@ -11,6 +11,10 @@ resource "google_spanner_database_iam_member" "service_spanner" {
   database = each.value.database
   role     = "roles/spanner.databaseUser"
   member   = "serviceAccount:${local.service_account_email}"
+
+  depends_on = [
+    var.spanner_ddl_dependency,
+  ]
 }
 
 locals {


### PR DESCRIPTION
This PR fixes a bug where IAM permissions would be set before the database exists. The reason is that the `google_spanner_database_iam_member` resource does not explicitly depend on the database. Its information are read from the Causa configuration instead.

To bring back this dependency, the `spanner_ddl_dependency` variable is used, in the same way it is used for the Cloud Run service itself.

### Commits

- 🐛 Ensure IAM permissions for Spanner depend on the databases
- 📝 Update changelog