### PR TITLE
✨ Support for Cloud Tasks triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Add support for Cloud Tasks triggers.
+
 Fixes:
 
 - Ensure IAM permissions for Spanner depend on the databases (the `spanner_ddl_dependency` variable).

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ locals {
   environment_variables = merge(
     local.pubsub_environment_variables,
     local.spanner_environment_variables,
+    local.tasks_environment_variables,
     local.conf_environment_variables,
     var.environment_variables
   )
@@ -67,9 +68,11 @@ locals {
   set_firestore_permissions = coalesce(var.set_firestore_permissions, var.set_iam_permissions)
   set_pubsub_permissions    = coalesce(var.set_pubsub_permissions, var.set_iam_permissions)
   set_spanner_permissions   = coalesce(var.set_spanner_permissions, var.set_iam_permissions)
+  set_tasks_permissions     = coalesce(var.set_tasks_permissions, var.set_iam_permissions)
 
   # Triggers.
   enable_pubsub_triggers = coalesce(var.enable_pubsub_triggers, var.enable_triggers)
+  enable_tasks_triggers  = coalesce(var.enable_tasks_triggers, var.enable_triggers)
 }
 
 data "google_project" "project" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,16 @@ output "name" {
   description = "The name of the Cloud Run service."
 }
 
+output "location" {
+  value       = google_cloud_run_service.service.location
+  description = "The location of the Cloud Run service."
+}
+
+output "project" {
+  value       = google_cloud_run_service.service.project
+  description = "The project of the Cloud Run service."
+}
+
 output "url" {
   value       = google_cloud_run_service.service.status[0].url
   description = "The URL to make requests to the Cloud Run service."
@@ -11,4 +21,9 @@ output "url" {
 output "public_http_endpoints" {
   description = "The list of public HTTP endpoints (routes) for the service."
   value       = var.enable_public_http_endpoints ? local.conf_http_endpoints : []
+}
+
+output "tasks_queues" {
+  description = "The IDs of Cloud Tasks queues created by the module for triggers defined in the configuration."
+  value       = { for name, queue in google_cloud_tasks_queue.queues : name => queue.id }
 }

--- a/tasks.tf
+++ b/tasks.tf
@@ -1,0 +1,94 @@
+locals {
+  # The map of triggers from the `serviceContainer.triggers` configuration, filtered to keep only Cloud Tasks triggers
+  # with a valid (HTTP) endpoint.
+  tasks_triggers = local.enable_tasks_triggers ? {
+    for key, value in local.conf_triggers :
+    key => value
+    if try(value.type, null) == "google.task" && try(value.endpoint.type, null) == "http"
+  } : {}
+
+  # The set of queue names obtained from Cloud Tasks triggers.
+  # See `random_string.queue_suffixes` for the reason behind suffixes.
+  tasks_queues = {
+    for trigger in values(local.tasks_triggers) :
+    trigger.queue => trigger
+  }
+  tasks_queue_names = {
+    for queue in keys(local.tasks_queues) :
+    queue => "${queue}-${random_string.queue_suffixes[queue].result}"
+  }
+
+  # Environment variables for the Cloud Tasks queues the service can create tasks into.
+  # This does not reference `google_cloud_tasks_queue.queues` on purpose to avoid future circular dependencies (see the
+  # comment about the `http_request` block).
+  tasks_environment_variables = {
+    for queue in keys(local.tasks_queues) :
+    "TASKS_QUEUE_${upper(replace(queue, "/[\\.-]{1}/", "_"))}"
+    => "projects/${local.gcp_project_id}/locations/${local.location}/queues/${local.tasks_queue_names[queue]}"
+  }
+}
+
+# Cloud Tasks queues cannot be quickly deleted then recreated with the same ID, which can cause problems when destroying
+# and recreating an environment. Adding a suffix to queue names works around that.
+resource "random_string" "queue_suffixes" {
+  for_each = local.tasks_queues
+
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "google_cloud_tasks_queue" "queues" {
+  for_each = local.tasks_queues
+
+  project  = local.gcp_project_id
+  location = local.location
+  name     = local.tasks_queue_names[each.key]
+
+  # When it becomes available, this should also set the `http_request` block. This would avoid having to pass the
+  # service's URL to itself. Instead, the `http_request` configuration at the queue level could reference
+  # `google_cloud_run_service.service.status[0].url` + the trigger's endpoint path.
+
+  retry_config {
+    max_attempts       = try(each.value.retryPolicy.maxAttempts, -1)
+    max_retry_duration = try(each.value.retryPolicy.maxRetryDuration, "0s")
+    min_backoff        = try(each.value.retryPolicy.minBackoff, "1s")
+    max_backoff        = try(each.value.retryPolicy.maxBackoff, "60s")
+    max_doublings      = try(each.value.retryPolicy.maxDoublings, 16)
+  }
+
+  stackdriver_logging_config {
+    sampling_ratio = 1
+  }
+}
+
+# Allows the service to enqueue expiration tasks in Cloud Tasks.
+resource "google_cloud_tasks_queue_iam_member" "tasks_enqueuer" {
+  for_each = local.set_tasks_permissions ? google_cloud_tasks_queue.queues : {}
+
+  project  = each.value.project
+  location = each.value.location
+  name     = each.value.name
+  role     = "roles/cloudtasks.enqueuer"
+  member   = "serviceAccount:${local.service_account_email}"
+}
+
+# Allows the service enqueuing tasks to set itself as the caller when performing the task's HTTP request.
+resource "google_service_account_iam_member" "service_own_user" {
+  count = local.set_tasks_permissions && length(local.tasks_triggers) > 0 ? 1 : 0
+
+  service_account_id = "projects/-/serviceAccounts/${local.service_account_email}"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${local.service_account_email}"
+}
+
+# Allows the service to invoke itself, when performing the task's HTTP request.
+resource "google_cloud_run_service_iam_member" "service_own_caller" {
+  count = local.set_tasks_permissions && length(local.tasks_triggers) > 0 ? 1 : 0
+
+  project  = google_cloud_run_service.service.project
+  location = google_cloud_run_service.service.location
+  service  = google_cloud_run_service.service.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${local.service_account_email}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,12 @@ variable "set_spanner_permissions" {
   default     = null
 }
 
+variable "set_tasks_permissions" {
+  type        = bool
+  description = "Whether IAM permissions on Cloud Tasks should be set so that the service account can enqueue tasks and call itself for queues defined in the service's triggers. Defaults to `set_iam_permissions`."
+  default     = null
+}
+
 variable "enable_triggers" {
   type        = bool
   description = "Whether triggers for the service should be configured."
@@ -162,6 +168,12 @@ variable "enable_triggers" {
 variable "enable_pubsub_triggers" {
   type        = bool
   description = "Whether Pub/Sub triggers for the service should be configured. Defaults to `enable_triggers`."
+  default     = null
+}
+
+variable "enable_tasks_triggers" {
+  type        = bool
+  description = "Whether Cloud Tasks triggers for the service should be configured. Defaults to `enable_triggers`."
   default     = null
 }
 


### PR DESCRIPTION
This PR implements the support for `google.tasks` triggers, by creating the corresponding Cloud Tasks queues and managing the related IAM permissions.

### Commits

- ✨ Support the automatic creation of Cloud Tasks queues and related permissions
- 📝 Document the Cloud Tasks triggers feature
- 📝 Update changelog