### PR TITLE
✨ API router integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Define the `routes` output, which integrates with the [`api-router`](https://github.com/causa-io/terraform-google-api-router) module.
+
 ## v0.5.0 (2023-09-08)
 
 Features:

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,13 @@ output "tasks_queues" {
   description = "The IDs of Cloud Tasks queues created by the module for triggers defined in the configuration."
   value       = { for name, queue in google_cloud_tasks_queue.queues : name => queue.id }
 }
+
+output "routes" {
+  value = {
+    paths   = var.enable_public_http_endpoints ? local.conf_http_endpoints : []
+    type    = "google.cloudRun"
+    region  = google_cloud_run_service.service.location
+    service = google_cloud_run_service.service.name
+  }
+  description = "The configuration that can be passed to the `api-router` module. Only relevant if the service exposes public HTTP endpoints."
+}


### PR DESCRIPTION
This PR implements the integration with the [`api-router`](https://github.com/causa-io/terraform-google-api-router) module. The `routes` output can be forwarded as one of the `services` values in the `api-router`'s variables.

### Commits

- ✨ Define the routes output
- 📝 Update changelog