### PR TITLE
💥 Pub/Sub triggers exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Pub/Sub triggers (push subscriptions) are now configured with [exponential backoff](https://cloud.google.com/pubsub/docs/handling-failures#exponential_backoff) by default, with the default Pub/Sub values of 10 seconds for minimum backoff, and 600 seconds for maximum backoff.
+
+Features:
+
+- Pub/Sub triggers exponential backoff can be configured using the `"google.pubSub".minimumBackoff` and `"google.pubSub".maximumBackoff` parameters on each trigger.
+
 ## v0.6.0 (2023-09-28)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,21 @@ Automatic definition of IAM permissions can be disabled by setting the `set_*_pe
 
 This module can also create and configure Pub/Sub push subscriptions for all event triggers defined in `serviceContainer.triggers`. For this, set the `enable_[pubsub_]triggers` variable to `true`.
 
-For each trigger with `type: event`, a Pub/Sub subscription for the `topic` with the push endpoint set to `endpoint.path` will be created. Pub/Sub will be configured such that calls to the service are authenticated using a dedicated service account.
+For each trigger with `type: event`, a Pub/Sub subscription for the `topic` with the push endpoint set to `endpoint.path` will be created. Pub/Sub will be configured such that calls to the service are authenticated using a dedicated service account. The exponential backoff for the retry policy can also be configured per trigger. For example, the service configuration could look something like:
+
+```yaml
+serviceContainer:
+  triggers:
+    myTrigger:
+      type: event
+      topic: my-pubsub-topic
+      endpoint:
+        type: http
+        path: /service/http/route
+      google.pubSub:
+        minimumBackoff: 1s
+        maximumBackoff: 100s
+```
 
 ### Cloud Tasks triggers (queues)
 


### PR DESCRIPTION
This PR introduces a breaking change, enabling exponential backoff for the retry policy as default (with Pub/Sub default values).
The minimum and maximum backoff can be configured for each trigger in the service's configuration.

### Commits

- ✨ Support configurable backoff values for Pub/Sub triggers
- 📝 Document Pub/Sub triggers exponential backoff configuration
- 📝 Update changelog