### PR TITLE
✨ Global Pub/Sub triggers backoff configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Allow setting a global Pub/Sub triggers backoff in the Causa configuration (`google.pubSub.[minimum|maximum]Backoff`) and the Terraform module (`pubsub_triggers_[minimum|maximum]_backoff` variables).
+
 ## v0.7.0 (2023-11-21)
 
 Breaking changes:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ serviceContainer:
       google.pubSub:
         minimumBackoff: 1s
         maximumBackoff: 100s
+
+# Default values for all triggers.
+google:
+  pubSub:
+    minimumBackoff: 10s
+    maximumBackoff: 600s
 ```
 
 ### Cloud Tasks triggers (queues)

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,9 @@ locals {
   conf_ingress                       = try(local.conf_cloud_run.ingress, null)
   conf_vpc_connector_name            = try(local.conf_cloud_run.vpcAccessConnector, null)
   conf_vpc_connector_egress_settings = try(local.conf_cloud_run.vpcAccessConnectorEgressSettings, null)
+  conf_pubsub                        = try(local.conf_google.pubSub, tomap({}))
+  conf_pubsub_minimum_backoff        = try(local.conf_pubsub.minimumBackoff, null)
+  conf_pubsub_maximum_backoff        = try(local.conf_pubsub.maximumBackoff, null)
 
   # Although unlikely, it is okay for this to fail if `google.cloudRun.dockerRepository` is not set, as long as
   # `var.image` is set.
@@ -59,10 +62,12 @@ locals {
     local.conf_environment_variables,
     var.environment_variables
   )
-  secret_environment_variables  = merge(local.conf_secret_environment_variables, var.secret_environment_variables)
-  ingress                       = coalesce(var.ingress, local.conf_ingress, "internal-and-cloud-load-balancing")
-  vpc_connector_name            = try(coalesce(var.vpc_connector_name, local.conf_vpc_connector_name), null)
-  vpc_connector_egress_settings = coalesce(var.vpc_connector_egress_settings, local.conf_vpc_connector_egress_settings, "all-traffic")
+  secret_environment_variables    = merge(local.conf_secret_environment_variables, var.secret_environment_variables)
+  ingress                         = coalesce(var.ingress, local.conf_ingress, "internal-and-cloud-load-balancing")
+  vpc_connector_name              = try(coalesce(var.vpc_connector_name, local.conf_vpc_connector_name), null)
+  vpc_connector_egress_settings   = coalesce(var.vpc_connector_egress_settings, local.conf_vpc_connector_egress_settings, "all-traffic")
+  pubsub_triggers_minimum_backoff = coalesce(var.pubsub_triggers_minimum_backoff, local.conf_pubsub_minimum_backoff, "10s")
+  pubsub_triggers_maximum_backoff = coalesce(var.pubsub_triggers_maximum_backoff, local.conf_pubsub_maximum_backoff, "600s")
 
   # Permissions.
   set_firestore_permissions = coalesce(var.set_firestore_permissions, var.set_iam_permissions)

--- a/pubsub-triggers.tf
+++ b/pubsub-triggers.tf
@@ -6,8 +6,8 @@ locals {
     key => {
       topic           = value.topic
       endpoint_path   = value.endpoint.path
-      minimum_backoff = try(value["google.pubSub"].minimumBackoff, "10s")
-      maximum_backoff = try(value["google.pubSub"].maximumBackoff, "600s")
+      minimum_backoff = try(value["google.pubSub"].minimumBackoff, local.pubsub_triggers_minimum_backoff)
+      maximum_backoff = try(value["google.pubSub"].maximumBackoff, local.pubsub_triggers_maximum_backoff)
     }
     if try(value.type, null) == "event" && try(value.endpoint.type, null) == "http"
   } : {}

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,18 @@ variable "vpc_connector_egress_settings" {
   default     = null
 }
 
+variable "pubsub_triggers_minimum_backoff" {
+  type        = string
+  description = "The minimum backoff for Pub/Sub triggers. Defaults to the `google.pubSub.minimumBackoff` configuration, or `10s`."
+  default     = null
+}
+
+variable "pubsub_triggers_maximum_backoff" {
+  type        = string
+  description = "The maximum backoff for Pub/Sub triggers. Defaults to the `google.pubSub.maximumBackoff` configuration, or `600s`."
+  default     = null
+}
+
 variable "ingress" {
   type        = string
   description = "The type of allowed ingress that can reach the container. Can be `all`, `internal`, `internal-and-cloud-load-balancing`. Defaults to the `google.cloudRun.ingress` configuration, or `internal-and-cloud-load-balancing`."


### PR DESCRIPTION
This PR improves on the "Pub/Sub triggers exponential backoff" feature by allowing setting global values to minimum and maximum backoff, either through the Causa configuration or using Terraform module variables.

### Commits

- ✨ Allow setting a global Pub/Sub triggers backoff in the Causa configuration and the Terraform module
- 📝 Update the documentation example for Pub/Sub triggers
- 📝 Update changelog