### PR TITLE
🔖 Prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.8.0 (2023-11-24)
+
 Features:
 
 - Allow setting a global Pub/Sub triggers backoff in the Causa configuration (`google.pubSub.[minimum|maximum]Backoff`) and the Terraform module (`pubsub_triggers_[minimum|maximum]_backoff` variables).


### PR DESCRIPTION
Features:

- Allow setting a global Pub/Sub triggers backoff in the Causa configuration (`google.pubSub.[minimum|maximum]Backoff`) and the Terraform module (`pubsub_triggers_[minimum|maximum]_backoff` variables).

### Commits

- 📝 Update changelog