### PR TITLE
💥 Cloud Run V2 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- The Cloud Run V2 API is now used through the `google_cloud_run_v2_service` resource. You can use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to reference an existing service, and `terraform state rm` to remove the existing `google_cloud_run_service` resource.
+- The `ingress` (`google.cloudRun.ingress`) and `vpc_connector_egress_settings` (`google.cloudRun.vpcAccessConnectorEgressSettings`) settings must use the enum values defined by the [V2 API](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.services).
+- The maximum number of instances (`max_instances` Terraform variable and `serviceContainer.maxInstances` configuration) is now set to `100` by default (which was already the default set by the Cloud Run API).
+
 ## v0.8.0 (2023-11-24)
 
 Features:

--- a/iam-cloud-run.tf
+++ b/iam-cloud-run.tf
@@ -6,8 +6,8 @@ resource "google_cloud_run_service_iam_member" "all_users" {
   count = var.enable_public_http_endpoints ? 1 : 0
 
   project  = local.gcp_project_id
-  location = google_cloud_run_service.service.location
-  service  = google_cloud_run_service.service.name
+  location = google_cloud_run_v2_service.service.location
+  service  = google_cloud_run_v2_service.service.name
   role     = "roles/run.invoker"
   member   = "allUsers"
 }

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ locals {
   cpu_limit            = coalesce(var.cpu_limit, local.conf_cpu_limit, "1000m")
   memory_limit         = coalesce(var.memory_limit, local.conf_memory_limit, "512Mi")
   min_instances        = try(coalesce(var.min_instances, local.conf_min_instances), null)
-  max_instances        = try(coalesce(var.max_instances, local.conf_max_instances), null)
+  max_instances        = try(coalesce(var.max_instances, local.conf_max_instances), 100)
   cpu_always_allocated = coalesce(var.cpu_always_allocated, local.conf_cpu_always_allocated, false)
   timeout              = try(coalesce(var.timeout, local.conf_timeout), null)
   request_concurrency  = try(coalesce(var.request_concurrency, local.conf_request_concurrency), null)
@@ -63,9 +63,9 @@ locals {
     var.environment_variables
   )
   secret_environment_variables    = merge(local.conf_secret_environment_variables, var.secret_environment_variables)
-  ingress                         = coalesce(var.ingress, local.conf_ingress, "internal-and-cloud-load-balancing")
+  ingress                         = coalesce(var.ingress, local.conf_ingress, "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER")
   vpc_connector_name              = try(coalesce(var.vpc_connector_name, local.conf_vpc_connector_name), null)
-  vpc_connector_egress_settings   = coalesce(var.vpc_connector_egress_settings, local.conf_vpc_connector_egress_settings, "all-traffic")
+  vpc_connector_egress_settings   = coalesce(var.vpc_connector_egress_settings, local.conf_vpc_connector_egress_settings, "ALL_TRAFFIC")
   pubsub_triggers_minimum_backoff = coalesce(var.pubsub_triggers_minimum_backoff, local.conf_pubsub_minimum_backoff, "10s")
   pubsub_triggers_maximum_backoff = coalesce(var.pubsub_triggers_maximum_backoff, local.conf_pubsub_maximum_backoff, "600s")
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,20 +1,20 @@
 output "name" {
-  value       = google_cloud_run_service.service.name
+  value       = google_cloud_run_v2_service.service.name
   description = "The name of the Cloud Run service."
 }
 
 output "location" {
-  value       = google_cloud_run_service.service.location
+  value       = google_cloud_run_v2_service.service.location
   description = "The location of the Cloud Run service."
 }
 
 output "project" {
-  value       = google_cloud_run_service.service.project
+  value       = google_cloud_run_v2_service.service.project
   description = "The project of the Cloud Run service."
 }
 
 output "url" {
-  value       = google_cloud_run_service.service.status[0].url
+  value       = google_cloud_run_v2_service.service.uri
   description = "The URL to make requests to the Cloud Run service."
 }
 
@@ -32,8 +32,8 @@ output "routes" {
   value = {
     paths   = var.enable_public_http_endpoints ? local.conf_http_endpoints : []
     type    = "google.cloudRun"
-    region  = google_cloud_run_service.service.location
-    service = google_cloud_run_service.service.name
+    region  = google_cloud_run_v2_service.service.location
+    service = google_cloud_run_v2_service.service.name
   }
   description = "The configuration that can be passed to the `api-router` module. Only relevant if the service exposes public HTTP endpoints."
 }

--- a/pubsub-triggers.tf
+++ b/pubsub-triggers.tf
@@ -33,7 +33,7 @@ resource "google_pubsub_subscription" "triggers" {
   }
 
   push_config {
-    push_endpoint = "${google_cloud_run_service.service.status[0].url}${each.value.endpoint_path}"
+    push_endpoint = "${google_cloud_run_v2_service.service.uri}${each.value.endpoint_path}"
 
     oidc_token {
       service_account_email = google_service_account.pubsub_trigger_invoker[0].email
@@ -55,8 +55,8 @@ resource "google_cloud_run_service_iam_member" "pubsub_trigger_invoker" {
   count = length(local.pubsub_triggers) > 0 ? 1 : 0
 
   project  = local.gcp_project_id
-  service  = google_cloud_run_service.service.name
-  location = google_cloud_run_service.service.location
+  service  = google_cloud_run_v2_service.service.name
+  location = google_cloud_run_v2_service.service.location
   role     = "roles/run.invoker"
   member   = "serviceAccount:${google_service_account.pubsub_trigger_invoker[0].email}"
 }

--- a/service.tf
+++ b/service.tf
@@ -3,120 +3,109 @@ locals {
     # Aliases are only required when the secret is stored in a different project. However one is assigned to each secret
     # to make configuration simpler.
     # The alias should start with `secret-` and its value should be the secret ID (not the version).
-    for key, secret_path in local.secret_environment_variables : key => {
-      alias = "secret-${random_uuid.secret_id[key].result}"
-      # `id` will be used for the alias definition and `version` by the environment variable.
-      secret = regex("(?P<id>projects\\/[\\w-]+\\/secrets\\/[\\w-]+)\\/versions\\/(?P<version>\\d+)", secret_path)
-    }
+    for key, secret_path in local.secret_environment_variables : key =>
+    regex("(?P<id>projects\\/[\\w-]+\\/secrets\\/[\\w-]+)\\/versions\\/(?P<version>\\d+)", secret_path)
   }
-}
 
-# The internal IDs used by each secret alias.
-resource "random_uuid" "secret_id" {
-  for_each = local.secret_environment_variables
+  # This module supports passing either the name of the connector (e.g. `my-connector`) or its full path (e.g.
+  # `projects/my-project/locations/my-location/connectors/my-connector`).
+  # If only the name is passed, the full name is inferred from the configured project ID and location.
+  vpc_connector_full_name = (
+    local.vpc_connector_name != null
+    ? try(regex("^projects\\/[\\w-]+\\/locations\\/[\\w-]+\\/connectors\\/[\\w-]+$", local.vpc_connector_name), null) != null
+    ? local.vpc_connector_name
+    : "projects/${local.gcp_project_id}/locations/${local.location}/connectors/${local.vpc_connector_name}"
+    : null
+  )
 }
 
 # The Cloud Run service itself.
-resource "google_cloud_run_service" "service" {
-  project                    = local.gcp_project_id
-  name                       = local.service_name
-  location                   = local.location
-  autogenerate_revision_name = true
+resource "google_cloud_run_v2_service" "service" {
+  project  = local.gcp_project_id
+  name     = local.service_name
+  location = local.location
 
-  metadata {
-    annotations = {
-      "run.googleapis.com/ingress" = local.ingress
-    }
-  }
+  ingress = local.ingress
 
   template {
-    spec {
-      containers {
-        image = local.image
+    containers {
+      image = local.image
 
-        resources {
-          limits = {
-            cpu    = local.cpu_limit
-            memory = local.memory_limit
-          }
+      resources {
+        limits = {
+          cpu    = local.cpu_limit
+          memory = local.memory_limit
         }
 
-        dynamic "env" {
-          for_each = local.environment_variables
-          iterator = env_var
+        cpu_idle = !local.cpu_always_allocated
+      }
 
-          content {
-            name  = env_var.key
-            value = env_var.value
-          }
+      dynamic "env" {
+        for_each = local.environment_variables
+        iterator = env_var
+
+        content {
+          name  = env_var.key
+          value = env_var.value
         }
+      }
 
-        dynamic "env" {
-          for_each = local.secret_environment_variables
-          iterator = env_var
+      dynamic "env" {
+        for_each = local.secret_environment_variables
+        iterator = env_var
 
-          content {
-            name = env_var.key
-            value_from {
-              secret_key_ref {
-                name = local.secrets[env_var.key].alias
-                key  = local.secrets[env_var.key].secret.version
-              }
-            }
-          }
-        }
-
-        dynamic "startup_probe" {
-          for_each = local.healthcheck_endpoint != null ? ["probe"] : []
-          iterator = probe
-
-          content {
-            http_get {
-              path = local.healthcheck_endpoint
-            }
-          }
-        }
-
-        dynamic "liveness_probe" {
-          for_each = local.healthcheck_endpoint != null ? ["probe"] : []
-          iterator = probe
-
-          content {
-            http_get {
-              path = local.healthcheck_endpoint
+        content {
+          name = env_var.key
+          value_source {
+            secret_key_ref {
+              secret  = local.secrets[env_var.key].id
+              version = local.secrets[env_var.key].version
             }
           }
         }
       }
 
-      timeout_seconds       = local.timeout
-      container_concurrency = local.request_concurrency
-      service_account_name  = local.service_account_email
+      dynamic "startup_probe" {
+        for_each = local.healthcheck_endpoint != null ? ["probe"] : []
+        iterator = probe
+
+        content {
+          http_get {
+            path = local.healthcheck_endpoint
+          }
+        }
+      }
+
+      dynamic "liveness_probe" {
+        for_each = local.healthcheck_endpoint != null ? ["probe"] : []
+        iterator = probe
+
+        content {
+          http_get {
+            path = local.healthcheck_endpoint
+          }
+        }
+      }
     }
 
-    metadata {
-      annotations = merge(
-        { "run.googleapis.com/cpu-throttling" = local.cpu_always_allocated ? "false" : "true" },
-        local.vpc_connector_name != null ? {
-          "run.googleapis.com/vpc-access-connector" = local.vpc_connector_name
-          "run.googleapis.com/vpc-access-egress"    = local.vpc_connector_egress_settings
-        } : {},
-        local.min_instances != null ? { "autoscaling.knative.dev/minScale" = "${local.min_instances}" } : {},
-        local.max_instances != null ? { "autoscaling.knative.dev/maxScale" = "${local.max_instances}" } : {},
-        # Defines aliases that are then referenced by environment variables.
-        length(local.secrets) > 0 ? {
-          "run.googleapis.com/secrets" = join(",", [for s in values(local.secrets) : "${s.alias}:${s.secret.id}"])
-        } : {}
-      )
-    }
-  }
+    timeout                          = local.timeout
+    max_instance_request_concurrency = local.request_concurrency
+    service_account                  = local.service_account_email
 
-  lifecycle {
-    # This might change outside Terraform.
-    ignore_changes = [
-      metadata[0].annotations["run.googleapis.com/operation-id"],
-      template[0].metadata[0].labels["run.googleapis.com/startupProbeType"],
-    ]
+    scaling {
+      min_instance_count = local.min_instances
+      max_instance_count = local.max_instances
+    }
+
+    dynamic "vpc_access" {
+      for_each = local.vpc_connector_full_name != null ? ["access"] : []
+      iterator = access
+
+      content {
+        connector = local.vpc_connector_full_name
+        egress    = local.vpc_connector_egress_settings
+      }
+    }
   }
 
   depends_on = [

--- a/tasks.tf
+++ b/tasks.tf
@@ -47,7 +47,7 @@ resource "google_cloud_tasks_queue" "queues" {
 
   # When it becomes available, this should also set the `http_request` block. This would avoid having to pass the
   # service's URL to itself. Instead, the `http_request` configuration at the queue level could reference
-  # `google_cloud_run_service.service.status[0].url` + the trigger's endpoint path.
+  # `google_cloud_run_v2_service.service.uri` + the trigger's endpoint path.
 
   retry_config {
     max_attempts       = try(each.value.retryPolicy.maxAttempts, -1)
@@ -86,9 +86,9 @@ resource "google_service_account_iam_member" "service_own_user" {
 resource "google_cloud_run_service_iam_member" "service_own_caller" {
   count = local.set_tasks_permissions && length(local.tasks_triggers) > 0 ? 1 : 0
 
-  project  = google_cloud_run_service.service.project
-  location = google_cloud_run_service.service.location
-  service  = google_cloud_run_service.service.name
+  project  = google_cloud_run_v2_service.service.project
+  location = google_cloud_run_v2_service.service.location
+  service  = google_cloud_run_v2_service.service.name
   role     = "roles/run.invoker"
   member   = "serviceAccount:${local.service_account_email}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -71,7 +71,7 @@ variable "min_instances" {
 
 variable "max_instances" {
   type        = number
-  description = "The maximum number of containers that can be deployed in response to input requests. Defaults to the `serviceContainer.maxInstances` configuration."
+  description = "The maximum number of containers that can be deployed in response to input requests. Defaults to the `serviceContainer.maxInstances` configuration, or `100`."
   default     = null
 }
 
@@ -83,13 +83,13 @@ variable "cpu_always_allocated" {
 
 variable "vpc_connector_name" {
   type        = string
-  description = "The name of the VPC access connector through which egress traffic should be routed. Defaults to the `google.cloudRun.vpcAccessConnector` configuration."
+  description = "The name of the VPC access connector through which egress traffic should be routed. This can be only the name or the full resource path. Defaults to the `google.cloudRun.vpcAccessConnector` configuration."
   default     = null
 }
 
 variable "vpc_connector_egress_settings" {
   type        = string
-  description = "The setting for egress traffic that goes through the VPC access connector. Can be `all-traffic` or `private-ranges-only`. Defaults to the `google.cloudRun.vpcAccessConnectorEgressSettings` configuration, or `all-traffic`."
+  description = "The setting for egress traffic that goes through the VPC access connector. Can be `ALL_TRAFFIC` or `PRIVATE_RANGES_ONLY`. Defaults to the `google.cloudRun.vpcAccessConnectorEgressSettings` configuration, or `ALL_TRAFFIC`."
   default     = null
 }
 
@@ -107,7 +107,7 @@ variable "pubsub_triggers_maximum_backoff" {
 
 variable "ingress" {
   type        = string
-  description = "The type of allowed ingress that can reach the container. Can be `all`, `internal`, `internal-and-cloud-load-balancing`. Defaults to the `google.cloudRun.ingress` configuration, or `internal-and-cloud-load-balancing`."
+  description = "The type of allowed ingress that can reach the container. Can be `INGRESS_TRAFFIC_ALL`, `INGRESS_TRAFFIC_INTERNAL_ONLY`, or `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER`. Defaults to the `google.cloudRun.ingress` configuration, or `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER`."
   default     = null
 }
 


### PR DESCRIPTION
This PR updates the Terraform module to make use of the Cloud Run V2 API. This implies using the `google_cloud_run_v2_service` resource rather than `google_cloud_run_service`.

Most of the exposed features are not impacted by this change. However, it is breaking because this is technically a different resource in Terraform.

### Commits

- 💥 Use the google_cloud_run_v2_service resource to define the Cloud Run service
- 📝 Update changelog