### PR TITLE
✨ Pub/Sub trigger message filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Breaking changes:
 - The `ingress` (`google.cloudRun.ingress`) and `vpc_connector_egress_settings` (`google.cloudRun.vpcAccessConnectorEgressSettings`) settings must use the enum values defined by the [V2 API](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.services).
 - The maximum number of instances (`max_instances` Terraform variable and `serviceContainer.maxInstances` configuration) is now set to `100` by default (which was already the default set by the Cloud Run API).
 
+Features:
+
+- Support Pub/Sub subscription message filtering using the `"google.pubSub".filter` trigger attribute.
+
 ## v0.8.0 (2023-11-24)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ serviceContainer:
       google.pubSub:
         minimumBackoff: 1s
         maximumBackoff: 100s
+        # Optional message filtering.
+        filter: attributes.eventName = "someEvent"
 
 # Default values for all triggers.
 google:

--- a/pubsub-triggers.tf
+++ b/pubsub-triggers.tf
@@ -8,6 +8,7 @@ locals {
       endpoint_path   = value.endpoint.path
       minimum_backoff = try(value["google.pubSub"].minimumBackoff, local.pubsub_triggers_minimum_backoff)
       maximum_backoff = try(value["google.pubSub"].maximumBackoff, local.pubsub_triggers_maximum_backoff)
+      filter          = try(value["google.pubSub"]["filter"], null)
     }
     if try(value.type, null) == "event" && try(value.endpoint.type, null) == "http"
   } : {}
@@ -21,6 +22,8 @@ resource "google_pubsub_subscription" "triggers" {
   # The subscriptions name is ensured to be unique by prefixing it with the service name.
   name  = "run-${local.service_name}-${each.key}"
   topic = local.pubsub_topic_ids[each.value.topic]
+
+  filter = each.value.filter
 
   ack_deadline_seconds = 600
   expiration_policy {


### PR DESCRIPTION
This PR implements optional filtering of Pub/Sub messages in a managed subscription. This allows a trigger to be called only when the filter expression evaluates to `true`.

### Commits

- ✨ Support the filters trigger attribute as a Pub/Sub subscription filter
- 📝 Update changelog
- 📝 Document Pub/Sub trigger message filtering