### PR TITLE
✨ Support for the `google.pubSub` trigger type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Support the `google.pubSub` trigger type as a way to receive messages from Pub/Sub topics not managed by Causa.
+
 ## v0.9.0 (2023-12-21)
 
 Breaking changes:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Automatic definition of IAM permissions can be disabled by setting the `set_*_pe
 
 This module can also create and configure Pub/Sub push subscriptions for all event triggers defined in `serviceContainer.triggers`. For this, set the `enable_[pubsub_]triggers` variable to `true`.
 
-For each trigger with `type: event`, a Pub/Sub subscription for the `topic` with the push endpoint set to `endpoint.path` will be created. Pub/Sub will be configured such that calls to the service are authenticated using a dedicated service account. The exponential backoff for the retry policy can also be configured per trigger. For example, the service configuration could look something like:
+For each trigger with `type: event` or `type: google.pubSub`, a Pub/Sub subscription for the `topic` with the push endpoint set to `endpoint.path` will be created. Pub/Sub will be configured such that calls to the service are authenticated using a dedicated service account. The exponential backoff for the retry policy can also be configured per trigger. For example, the service configuration could look something like:
 
 ```yaml
 serviceContainer:
@@ -68,6 +68,8 @@ google:
     minimumBackoff: 10s
     maximumBackoff: 600s
 ```
+
+> 💡 The `google.pubSub` type can be used in place of the `event` type for topics that are not managed by Causa. This allows defining triggers that will not be included in the rest of Causa event-related tooling (e.g. code generation).
 
 ### Cloud Tasks triggers (queues)
 

--- a/pubsub-triggers.tf
+++ b/pubsub-triggers.tf
@@ -10,7 +10,7 @@ locals {
       maximum_backoff = try(value["google.pubSub"].maximumBackoff, local.pubsub_triggers_maximum_backoff)
       filter          = try(value["google.pubSub"]["filter"], null)
     }
-    if try(value.type, null) == "event" && try(value.endpoint.type, null) == "http"
+    if contains(["event", "google.pubSub"], try(value.type, null)) && try(value.endpoint.type, null) == "http"
   } : {}
 }
 

--- a/pubsub.tf
+++ b/pubsub.tf
@@ -7,7 +7,7 @@ locals {
   )
 
   # The map between event full names and Pub/Sub topic IDs.
-  # This defaults to topics in the set GCP project, but can be overridden by the user (especially usefull to express the
+  # This defaults to topics in the set GCP project, but can be overridden by the user (especially useful to express the
   # dependency on the Pub/Sub topic resources).
   pubsub_topic_ids = merge(
     { for topic in local.referenced_topics : topic => "projects/${local.gcp_project_id}/topics/${topic}" },


### PR DESCRIPTION
This PR adds support for the `google.pubSub` trigger type in exactly the same way as the `event` type.
The reason for this feature is that this allows the definition of triggers on topics that are not managed by Causa.
For Causa-managed topics, the `event` type is still recommended as this will enable other Causa features (e.g. code generation).
However, using `event` for an arbitrary Pub/Sub topic will make code generation fail. Using `google.pubSub` solves that, as the trigger is not included in the rest of Causa's tooling.

### Commits

- ✨ Support the google.pubSub trigger type in addition to event
- ✏️ Fix typo in comment
- 📝 Document the google.pubSub trigger type
- 📝 Update changelog