### PR TITLE
✨ Custom request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Forward custom request headers from the configuration or input variable to the `routes` output.
+
 ## v0.10.1 (2024-02-21)
 
 Chores:

--- a/main.tf
+++ b/main.tf
@@ -37,24 +37,27 @@ locals {
   conf_pubsub                        = try(local.conf_google.pubSub, tomap({}))
   conf_pubsub_minimum_backoff        = try(local.conf_pubsub.minimumBackoff, null)
   conf_pubsub_maximum_backoff        = try(local.conf_pubsub.maximumBackoff, null)
+  conf_google_load_balancing         = try(local.conf_google.loadBalancing, tomap({}))
+  conf_custom_request_headers        = try(local.conf_google_load_balancing.customRequestHeaders, toset([]))
 
   # Although unlikely, it is okay for this to fail if `google.cloudRun.dockerRepository` is not set, as long as
   # `var.image` is set.
   conf_image = try("${local.conf_cloud_run.dockerRepository}/${local.conf_project_name}:${local.conf_active_version}", null)
 
   # Configuration with variable overrides.
-  gcp_project_id       = coalesce(var.gcp_project_id, local.conf_google_project)
-  service_name         = coalesce(var.name, local.conf_project_name)
-  location             = coalesce(var.location, local.conf_location)
-  image                = coalesce(var.image, local.conf_image)
-  cpu_limit            = coalesce(var.cpu_limit, local.conf_cpu_limit, "1000m")
-  memory_limit         = coalesce(var.memory_limit, local.conf_memory_limit, "512Mi")
-  min_instances        = try(coalesce(var.min_instances, local.conf_min_instances), null)
-  max_instances        = try(coalesce(var.max_instances, local.conf_max_instances), 100)
-  cpu_always_allocated = coalesce(var.cpu_always_allocated, local.conf_cpu_always_allocated, false)
-  timeout              = try(coalesce(var.timeout, local.conf_timeout), null)
-  request_concurrency  = try(coalesce(var.request_concurrency, local.conf_request_concurrency), null)
-  healthcheck_endpoint = var.healthcheck_endpoint
+  gcp_project_id         = coalesce(var.gcp_project_id, local.conf_google_project)
+  service_name           = coalesce(var.name, local.conf_project_name)
+  location               = coalesce(var.location, local.conf_location)
+  image                  = coalesce(var.image, local.conf_image)
+  cpu_limit              = coalesce(var.cpu_limit, local.conf_cpu_limit, "1000m")
+  memory_limit           = coalesce(var.memory_limit, local.conf_memory_limit, "512Mi")
+  min_instances          = try(coalesce(var.min_instances, local.conf_min_instances), null)
+  max_instances          = try(coalesce(var.max_instances, local.conf_max_instances), 100)
+  custom_request_headers = coalesce(var.custom_request_headers, local.conf_custom_request_headers, toset([]))
+  cpu_always_allocated   = coalesce(var.cpu_always_allocated, local.conf_cpu_always_allocated, false)
+  timeout                = try(coalesce(var.timeout, local.conf_timeout), null)
+  request_concurrency    = try(coalesce(var.request_concurrency, local.conf_request_concurrency), null)
+  healthcheck_endpoint   = var.healthcheck_endpoint
   environment_variables = merge(
     local.pubsub_environment_variables,
     local.spanner_environment_variables,

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,10 +30,11 @@ output "tasks_queues" {
 
 output "routes" {
   value = {
-    paths   = var.enable_public_http_endpoints ? local.conf_http_endpoints : []
-    type    = "google.cloudRun"
-    region  = google_cloud_run_v2_service.service.location
-    service = google_cloud_run_v2_service.service.name
+    paths                  = var.enable_public_http_endpoints ? local.conf_http_endpoints : []
+    type                   = "google.cloudRun"
+    region                 = google_cloud_run_v2_service.service.location
+    service                = google_cloud_run_v2_service.service.name
+    custom_request_headers = local.custom_request_headers
   }
   description = "The configuration that can be passed to the `api-router` module. Only relevant if the service exposes public HTTP endpoints."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -141,6 +141,12 @@ variable "pubsub_topic_ids" {
   default     = {}
 }
 
+variable "custom_request_headers" {
+  type        = set(string)
+  description = "A list of custom request headers that should be set by the API router. This simply sets the corresponding field in the `routes` output. Defaults to the `google.loadBalancing.customRequestHeaders` configuration."
+  default     = null
+}
+
 variable "set_iam_permissions" {
   type        = bool
   description = "Whether IAM permissions should be set so that the service account can access resources defined in the service's outputs."


### PR DESCRIPTION
This PR exposes a new variable, `custom_request_headers`, and parses the new `google.loadBalancing.customRequestHeaders` configuration value. Custom request headers are simply passed to the `routes` output, as they are used by the [api-router](https://github.com/causa-io/terraform-google-api-router) Terraform module.

### Commits

- **✨ Forward custom request headers from the configuration or input variables**
- **📝 Update changelog**