### PR TITLE
`triggers` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Support Terraform-defined triggers using the `triggers` module variable.
+
 ## v0.12.0 (2024-05-02)
 
 Features:

--- a/eventarc-triggers.tf
+++ b/eventarc-triggers.tf
@@ -2,7 +2,7 @@ locals {
   # The map of triggers from the `serviceContainer.triggers` configuration, filtered to keep only Eventarc triggers with
   # a valid (HTTP) endpoint.
   eventarc_triggers = local.enable_eventarc_triggers ? {
-    for key, value in local.conf_triggers :
+    for key, value in local.triggers :
     key => {
       endpoint_path = value.endpoint.path
       content_type  = value["google.eventarc"].contentType

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ locals {
   vpc_connector_egress_settings   = coalesce(var.vpc_connector_egress_settings, local.conf_vpc_connector_egress_settings, "ALL_TRAFFIC")
   pubsub_triggers_minimum_backoff = coalesce(var.pubsub_triggers_minimum_backoff, local.conf_pubsub_minimum_backoff, "10s")
   pubsub_triggers_maximum_backoff = coalesce(var.pubsub_triggers_maximum_backoff, local.conf_pubsub_maximum_backoff, "600s")
+  triggers                        = merge(local.conf_triggers, var.triggers)
 
   # Permissions.
   set_firestore_permissions = coalesce(var.set_firestore_permissions, var.set_iam_permissions)

--- a/pubsub-triggers.tf
+++ b/pubsub-triggers.tf
@@ -2,7 +2,7 @@ locals {
   # The map of triggers from the `serviceContainer.triggers` configuration, filtered to keep only Pub/Sub triggers with
   # a valid (HTTP) endpoint.
   pubsub_triggers = local.enable_pubsub_triggers ? {
-    for key, value in local.conf_triggers :
+    for key, value in local.triggers :
     key => {
       topic           = value.topic
       endpoint_path   = value.endpoint.path

--- a/tasks.tf
+++ b/tasks.tf
@@ -2,7 +2,7 @@ locals {
   # The map of triggers from the `serviceContainer.triggers` configuration, filtered to keep only Cloud Tasks triggers
   # with a valid (HTTP) endpoint.
   tasks_triggers = local.enable_tasks_triggers ? {
-    for key, value in local.conf_triggers :
+    for key, value in local.triggers :
     key => value
     if try(value.type, null) == "google.task" && try(value.endpoint.type, null) == "http"
   } : {}

--- a/variables.tf
+++ b/variables.tf
@@ -206,3 +206,9 @@ variable "spanner_ddl_dependency" {
   description = "The DDL for the (Spanner) database that the service depends on. This is used to ensure that the database is created and updated before the service is deployed."
   default     = []
 }
+
+variable "triggers" {
+  type        = map(any)
+  description = "A map of triggers for the service. They will be merged with the `serviceContainer.triggers` configuration."
+  default     = {}
+}


### PR DESCRIPTION
This implements the support for the `triggers` variable. This allows defining other triggers, in addition to the `serviceContainer.triggers` configuration.
Triggers from both sources are merged (with the `triggers` variable overriding existing triggers from the configuration).

### Commits

- **✨ Support Terraform-defined triggers using the triggers module variable**
- **📝 Update changelog**