### PR TITLE
🔖 Prepare v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.14.1 (2024-08-06)
+
 Fixes:
 
 - Make the Cloud Run service depend on Secret Manager permissions.


### PR DESCRIPTION
Fixes:

- Make the Cloud Run service depend on Secret Manager permissions.

### Commits

- **📝 Update changelog**