### PR TITLE
✨ Support override of the `active_version` using the corresponding variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Support override of the `active_version` using the corresponding variable.
+
 ## v0.14.1 (2024-08-06)
 
 Fixes:

--- a/main.tf
+++ b/main.tf
@@ -42,11 +42,14 @@ locals {
 
   # Although unlikely, it is okay for this to fail if `google.cloudRun.dockerRepository` is not set, as long as
   # `var.image` is set.
-  conf_image = try("${local.conf_cloud_run.dockerRepository}/${local.conf_project_name}:${local.conf_active_version}", null)
+  # The local `active_version` is used, to allow a possible override by the `active_version` variable, even when the
+  # full image URL is obtained from the configuration.
+  conf_image = try("${local.conf_cloud_run.dockerRepository}/${local.conf_project_name}:${local.active_version}", null)
 
   # Configuration with variable overrides.
   gcp_project_id         = coalesce(var.gcp_project_id, local.conf_google_project)
   service_name           = coalesce(var.name, local.conf_project_name)
+  active_version         = coalesce(var.active_version, local.conf_active_version)
   location               = coalesce(var.location, local.conf_location)
   image                  = coalesce(var.image, local.conf_image)
   cpu_limit              = coalesce(var.cpu_limit, local.conf_cpu_limit, "1000m")

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "name" {
   default     = null
 }
 
+variable "active_version" {
+  type        = string
+  description = "The version of the service to deploy. Defaults to `project.activeVersion`."
+  default     = null
+}
+
 variable "service_account" {
   // Using an object allows to differentiate between the default `null` value and an email that would be passed, even at
   // plan time. If the service account email references a service account resource that hasn't been created yet, the


### PR DESCRIPTION
The title says it all. The new `active_version` variable allows overriding the `project.activeVersion` configuration, while keeping the logic that builds the Docker image URL from the service name and the Docker repository URL.

### Commits

- **✨ Support override of the active version using the corresponding variable.**
- **📝 Update changelog**