### PR TITLE
💥 Cloud Tasks queue-level HTTP configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Override the [HTTP target](https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues#httptarget) for the managed Cloud Tasks queues. This allows the service creating tasks to leave HTTP configuration up to the queue, such that it doesn't have to know its own URI.
+
 ## v0.15.1 (2024-08-30)
 
 Chores:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ google:
 
 Similarly to Pub/Sub triggers, this module can also manage Cloud Tasks queues for corresponding triggers. The `enable_[tasks_]triggers` variable should be set to `true`.
 
-For each trigger with `type: google.task`, a Cloud Tasks queue will be created with the name of the `queue` attribute for the trigger (plus a suffix). The `endpoint` configuration is identical to Pub/Sub, and must reference an HTTP endpoint for the service. Although this is not currently used by the module, the endpoint will be used to configured queue-level HTTP requests in the future.
+For each trigger with `type: google.task`, a Cloud Tasks queue will be created with the name of the `queue` attribute for the trigger (plus a suffix). The `endpoint` configuration is identical to Pub/Sub, and must reference an HTTP endpoint for the service. The endpoint is used to configured queue-level HTTP requests.
 
 If `set_[iam|tasks]_permissions` is `true`, the IAM permissions will be configured such that the service can:
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.75.0, < 7.0"
+      version = ">= 6.1.0, < 7.0"
     }
 
     random = {


### PR DESCRIPTION
This introduces a breaking change for managed Cloud Tasks. They are now configured with HTTP overrides to automatically provide the tasks' URI, based on the service's URI. This means that the service no longer has to be aware of its own URI, which was inconvenient as the URI is only known once the Cloud Run service is deployed.

### Commits

- **💥 Only support Google provider from version 6.1.0**
- **💥 Define the HTTP target in managed Cloud Tasks queues, overriding the URI configured in tasks**
- **📝 Update documentation for Cloud Tasks**
- **📝 Update changelog**