### PR TITLE
🔖 Prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.16.0 (2024-09-11)
+
 Breaking changes:
 
 - Override the [HTTP target](https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues#httptarget) for the managed Cloud Tasks queues. This allows the service creating tasks to leave HTTP configuration up to the queue, such that it doesn't have to know its own URI.


### PR DESCRIPTION
Breaking changes:

- Override the [HTTP target](https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues#httptarget) for the managed Cloud Tasks queues. This allows the service creating tasks to leave HTTP configuration up to the queue, such that it doesn't have to know its own URI.

### Commits

- **📝 Update changelog**