### PR TITLE
✨ Startup CPU boost support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Support the `startup_cpu_boost` variable and `google.cloudRun.startupCpuBoost` configuration.
+
 ## v0.16.0 (2024-09-11)
 
 Breaking changes:

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ locals {
   conf_location                      = try(local.conf_cloud_run.location, null)
   conf_secret_environment_variables  = try(local.conf_cloud_run.secretEnvironmentVariables, tomap({}))
   conf_cpu_always_allocated          = try(local.conf_cloud_run.cpuAlwaysAllocated, null)
+  conf_startup_cpu_boost             = try(local.conf_cloud_run.startupCpuBoost, null)
   conf_timeout                       = try(local.conf_cloud_run.timeout, null)
   conf_request_concurrency           = try(local.conf_cloud_run.requestConcurrency, null)
   conf_ingress                       = try(local.conf_cloud_run.ingress, null)
@@ -58,6 +59,7 @@ locals {
   max_instances          = try(coalesce(var.max_instances, local.conf_max_instances), 100)
   custom_request_headers = coalesce(var.custom_request_headers, local.conf_custom_request_headers, toset([]))
   cpu_always_allocated   = coalesce(var.cpu_always_allocated, local.conf_cpu_always_allocated, false)
+  startup_cpu_boost      = coalesce(var.startup_cpu_boost, local.conf_startup_cpu_boost, false)
   timeout                = try(coalesce(var.timeout, local.conf_timeout), null)
   request_concurrency    = try(coalesce(var.request_concurrency, local.conf_request_concurrency), null)
   healthcheck_endpoint   = var.healthcheck_endpoint

--- a/service.tf
+++ b/service.tf
@@ -29,7 +29,8 @@ resource "google_cloud_run_v2_service" "service" {
           memory = local.memory_limit
         }
 
-        cpu_idle = !local.cpu_always_allocated
+        cpu_idle          = !local.cpu_always_allocated
+        startup_cpu_boost = local.startup_cpu_boost
       }
 
       dynamic "env" {

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "cpu_always_allocated" {
   default     = null
 }
 
+variable "startup_cpu_boost" {
+  type        = bool
+  description = "Whether the container should be given a CPU boost during startup. Defaults to the `google.cloudRun.startupCpuBoost` configuration, or `false`."
+  default     = null
+}
+
 variable "vpc_connector_name" {
   type        = string
   description = "The name of the VPC access connector through which egress traffic should be routed. This can be only the name or the full resource path. Defaults to the `google.cloudRun.vpcAccessConnector` configuration."


### PR DESCRIPTION
The title says it all. This supports the corresponding `google_cloud_run_v2_service` variable.

### Commits

- **✨ Support the startup_cpu_boost variable and google.cloudRun.startupCpuBoost configuration**
- **📝 Update changelog**