### PR TITLE
🔖 Prepare v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.17.1 (2025-09-12)
+
 Chores:
 
 - Upgrade compatible `google` provider versions to support `7.*.*`.


### PR DESCRIPTION
Chores:

- Upgrade compatible `google` provider versions to support `7.*.*`.