### PR TITLE
✨ Configure monitoring IAM permissions required by the Spanner clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Configure monitoring IAM permissions required by the Spanner clients.
+
 ## v0.17.1 (2025-09-12)
 
 Chores:

--- a/service.tf
+++ b/service.tf
@@ -107,5 +107,6 @@ resource "google_cloud_run_v2_service" "service" {
     google_pubsub_topic_iam_member.service_pubsub_publisher,
     google_project_iam_member.service_firestore_user,
     google_secret_manager_secret_iam_member.service_secrets,
+    google_project_iam_member.service_monitoring_metric_writer,
   ]
 }


### PR DESCRIPTION
See https://cloud.google.com/spanner/docs/view-manage-client-side-metrics#access-client-side-metrics.
Unfortunately, granting the regular Spanner role at the database is not enough, because the monitoring permission needs to be granted at the project level.