### PR TITLE
🔖 Prepare v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.23.0 (2026-03-09)
+
 Features:
 
 - Make the project and version optional when referencing secrets in `secret_environment_variables`, defaulting to the current GCP project and `latest`.


### PR DESCRIPTION
Features:

- Make the project and version optional when referencing secrets in `secret_environment_variables`, defaulting to the current GCP project and `latest`.