### PR TITLE
💥 Configure health checks through the project configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Remove the `healthcheck_endpoint` variable. Health checks are now configured exclusively through the `serviceContainer.healthCheck` configuration.
+
+Features:
+
+- Add the `serviceContainer.healthCheck` configuration, with independent `startup` and `liveness` blocks supporting `path`, `initialDelay`, `period`, `timeout`, and `failureThreshold`. Setting `healthCheck`, `healthCheck.startup`, or `healthCheck.liveness` to `null` disables the corresponding probe(s).
+
 ## v0.23.0 (2026-03-09)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ The main resource managed by this module is the Cloud Run service itself, for wh
 
 By default, the Cloud Run service cannot be accessed publicly. To allow unauthenticated requests (as in, not using IAM) to the service, set `enable_public_http_endpoints` to `true`. This will also populate the `public_http_endpoints` output, which will contain the `serviceContainer.endpoints.http` configuration from `causa.yaml` and can be used as input for setting up a load balancer.
 
+### Health checks
+
+Startup and liveness HTTP probes are configured through `serviceContainer.healthCheck`. By default, both probes are enabled with `path: /health` and the provider's default timing values. Each block accepts `path`, `initialDelay`, `period`, `timeout`, and `failureThreshold`. Setting `healthCheck.startup` or `healthCheck.liveness` to `null` disables the corresponding probe; setting `healthCheck` itself to `null` disables both.
+
+```yaml
+serviceContainer:
+  healthCheck:
+    startup:
+      path: /health/startup
+      period: 5
+      failureThreshold: 10
+    liveness:
+      path: /health
+```
+
 ### IAM permissions
 
 Based on the `causa.yaml` configuration, this module can also manage required permissions for the service. This includes:

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,25 @@ locals {
   conf_min_instances         = try(local.conf_service_container.minInstances, null)
   conf_max_instances         = try(local.conf_service_container.maxInstances, null)
 
+  conf_healthcheck          = try(local.conf_service_container.healthCheck, {})
+  conf_healthcheck_startup  = local.conf_healthcheck == null ? null : try(local.conf_healthcheck.startup, {})
+  conf_healthcheck_liveness = local.conf_healthcheck == null ? null : try(local.conf_healthcheck.liveness, {})
+
+  startup_probe = local.conf_healthcheck_startup == null ? null : {
+    path              = try(local.conf_healthcheck_startup.path, "/health")
+    initial_delay     = try(local.conf_healthcheck_startup.initialDelay, null)
+    period            = try(local.conf_healthcheck_startup.period, null)
+    timeout           = try(local.conf_healthcheck_startup.timeout, null)
+    failure_threshold = try(local.conf_healthcheck_startup.failureThreshold, null)
+  }
+  liveness_probe = local.conf_healthcheck_liveness == null ? null : {
+    path              = try(local.conf_healthcheck_liveness.path, "/health")
+    initial_delay     = try(local.conf_healthcheck_liveness.initialDelay, null)
+    period            = try(local.conf_healthcheck_liveness.period, null)
+    timeout           = try(local.conf_healthcheck_liveness.timeout, null)
+    failure_threshold = try(local.conf_healthcheck_liveness.failureThreshold, null)
+  }
+
   conf_outputs              = try(local.conf_service_container.outputs, tomap({}))
   conf_event_topics_outputs = try(local.conf_outputs.eventTopics, [])
   conf_firestore_outputs    = try(local.conf_outputs["google.firestore"], [])
@@ -69,7 +88,6 @@ locals {
   startup_cpu_boost      = coalesce(var.startup_cpu_boost, local.conf_startup_cpu_boost, false)
   timeout                = try(coalesce(var.timeout, local.conf_timeout), null)
   request_concurrency    = try(coalesce(var.request_concurrency, local.conf_request_concurrency), null)
-  healthcheck_endpoint   = var.healthcheck_endpoint
   environment_variables = merge(
     local.pubsub_environment_variables,
     local.spanner_environment_variables,

--- a/service.tf
+++ b/service.tf
@@ -65,24 +65,32 @@ resource "google_cloud_run_v2_service" "service" {
       }
 
       dynamic "startup_probe" {
-        for_each = local.healthcheck_endpoint != null ? ["probe"] : []
+        for_each = local.startup_probe != null ? [local.startup_probe] : []
         iterator = probe
 
         content {
           http_get {
-            path = local.healthcheck_endpoint
+            path = probe.value.path
           }
+          initial_delay_seconds = probe.value.initial_delay
+          period_seconds        = probe.value.period
+          timeout_seconds       = probe.value.timeout
+          failure_threshold     = probe.value.failure_threshold
         }
       }
 
       dynamic "liveness_probe" {
-        for_each = local.healthcheck_endpoint != null ? ["probe"] : []
+        for_each = local.liveness_probe != null ? [local.liveness_probe] : []
         iterator = probe
 
         content {
           http_get {
-            path = local.healthcheck_endpoint
+            path = probe.value.path
           }
+          initial_delay_seconds = probe.value.initial_delay
+          period_seconds        = probe.value.period
+          timeout_seconds       = probe.value.timeout
+          failure_threshold     = probe.value.failure_threshold
         }
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -171,12 +171,6 @@ variable "request_concurrency" {
   default     = null
 }
 
-variable "healthcheck_endpoint" {
-  type        = string
-  description = "The endpoint to check to determine whether the container is healthy. Defaults to `/health`. Can be set to `null` to disable health checks."
-  default     = "/health"
-}
-
 variable "enable_public_http_endpoints" {
   type        = bool
   description = "Whether the service should be accessible publicly (possibly behind a load balancer). This sets the output `public_http_endpoints`."


### PR DESCRIPTION
Startup and liveness HTTP probes are now configured through the `serviceContainer.healthCheck` section of the project configuration, with independent `startup` and `liveness` blocks supporting `path`, `initialDelay`, `period`, `timeout`, and `failureThreshold`. By default, both probes remain enabled on `/health`. Setting `healthCheck`, `healthCheck.startup`, or `healthCheck.liveness` to `null` disables the corresponding probe(s).

The `healthcheck_endpoint` Terraform variable has been removed. Consumers that relied on it must move the configuration to `serviceContainer.healthCheck` in the project configuration file. Disabling probes (previously `healthcheck_endpoint = null`) is now done with `healthCheck: null`, and overriding the path with `healthCheck.{startup,liveness}.path`.