### PR TITLE
🔖 Prepare v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.24.0 (2026-05-19)
+
 Breaking changes:
 
 - Remove the `healthcheck_endpoint` variable. Health checks are now configured exclusively through the `serviceContainer.healthCheck` configuration.


### PR DESCRIPTION
Breaking changes:

- Remove the `healthcheck_endpoint` variable. Health checks are now configured exclusively through the `serviceContainer.healthCheck` configuration.

Features:

- Add the `serviceContainer.healthCheck` configuration, with independent `startup` and `liveness` blocks supporting `path`, `initialDelay`, `period`, `timeout`, and `failureThreshold`. Setting `healthCheck`, `healthCheck.startup`, or `healthCheck.liveness` to `null` disables the corresponding probe(s).