### PR TITLE
✨ Support disabling triggers via the `enabled` boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Support the `enabled` boolean on any trigger. When set to `false`, the trigger is paused where its resource supports it (Cloud Tasks queues via `desired_state`, Cloud Scheduler jobs via `paused`) and removed otherwise (Pub/Sub, Eventarc).
+
 ## v0.24.0 (2026-05-19)
 
 Breaking changes:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ Based on the `causa.yaml` configuration, this module can also manage required pe
 
 Automatic definition of IAM permissions can be disabled by setting the `set_*_permissions` variables to `false`.
 
+### Disabling a trigger
+
+Any trigger can be disabled by setting its `enabled` property to `false`:
+
+```yaml
+serviceContainer:
+  triggers:
+    myTrigger:
+      enabled: false
+      type: event
+      topic: my-pubsub-topic
+      endpoint:
+        type: http
+        path: /service/http/route
+```
+
+How a disabled trigger is handled depends on what its underlying resource supports, so that disabling is reversible without destroying state where possible:
+
+- **Cloud Tasks** triggers keep their queue (and `TASKS_QUEUE_*` environment variable), but the queue is paused (`desired_state = "PAUSED"`) so tasks are no longer dispatched. The service can still enqueue tasks.
+- **Cron** triggers keep their Cloud Scheduler job, but it is paused (`paused = true`) so it no longer runs.
+- **Pub/Sub** and **Eventarc** triggers have no paused state, so a disabled trigger is simply not created.
+
 ### Pub/Sub triggers
 
 This module can also create and configure Pub/Sub push subscriptions for all event triggers defined in `serviceContainer.triggers`. For this, set the `enable_[pubsub_]triggers` variable to `true`.

--- a/cron-triggers.tf
+++ b/cron-triggers.tf
@@ -4,6 +4,7 @@ locals {
   cron_triggers = local.enable_cron_triggers ? {
     for key, value in local.triggers :
     key => {
+      paused               = try(value.enabled, true) == false
       schedule             = value.schedule
       timezone             = try(value.timezone, null)
       endpoint_path        = value.endpoint.path
@@ -48,6 +49,7 @@ resource "google_cloud_scheduler_job" "triggers" {
   description = "Cron trigger '${each.key}' for the Cloud Run ${local.service_name} service."
   schedule    = each.value.schedule
   time_zone   = each.value.timezone
+  paused      = each.value.paused
 
   http_target {
     uri         = "${google_cloud_run_v2_service.service.uri}${each.value.endpoint_path}"

--- a/eventarc-triggers.tf
+++ b/eventarc-triggers.tf
@@ -16,7 +16,7 @@ locals {
         }
       ]
     }
-    if try(value.type, null) == "google.eventarc" && try(value.endpoint.type, null) == "http"
+    if try(value.type, null) == "google.eventarc" && try(value.endpoint.type, null) == "http" && try(value.enabled, true) != false
   } : {}
 
   # The set of GCS buckets referenced by Eventarc triggers. Used to configure IAM permissions.

--- a/pubsub-triggers.tf
+++ b/pubsub-triggers.tf
@@ -10,7 +10,7 @@ locals {
       maximum_backoff = try(value["google.pubSub"].maximumBackoff, local.pubsub_triggers_maximum_backoff)
       filter          = try(value["google.pubSub"]["filter"], null)
     }
-    if contains(["event", "google.pubSub"], try(value.type, null)) && try(value.endpoint.type, null) == "http"
+    if contains(["event", "google.pubSub"], try(value.type, null)) && try(value.endpoint.type, null) == "http" && try(value.enabled, true) != false
   } : {}
 }
 

--- a/tasks.tf
+++ b/tasks.tf
@@ -3,7 +3,16 @@ locals {
   # with a valid (HTTP) endpoint.
   tasks_triggers = local.enable_tasks_triggers ? {
     for key, value in local.triggers :
-    key => value
+    key => {
+      queue              = value.queue
+      endpoint_path      = value.endpoint.path
+      paused             = try(value.enabled, true) == false
+      max_attempts       = try(value.retryPolicy.maxAttempts, -1)
+      max_retry_duration = try(value.retryPolicy.maxRetryDuration, "0s")
+      min_backoff        = try(value.retryPolicy.minBackoff, "1s")
+      max_backoff        = try(value.retryPolicy.maxBackoff, "60s")
+      max_doublings      = try(value.retryPolicy.maxDoublings, 16)
+    }
     if contains(["task", "google.task", "google.tasks"], try(value.type, null)) && try(value.endpoint.type, null) == "http"
   } : {}
 
@@ -45,6 +54,8 @@ resource "google_cloud_tasks_queue" "queues" {
   location = local.location
   name     = local.tasks_queue_names[each.key]
 
+  desired_state = each.value.paused ? "PAUSED" : "RUNNING"
+
   # This configuration avoids having to pass the service's URI to itself when creating new tasks (at runtime).
   # This is especially useful because the service's URI is not known until the service is created, which makes it hard
   # to "inject" into the service. Configuring the URI at the task level allows the service to create tasks without
@@ -57,7 +68,7 @@ resource "google_cloud_tasks_queue" "queues" {
       host   = replace(google_cloud_run_v2_service.service.uri, "/^https:\\/\\//", "")
 
       path_override {
-        path = each.value.endpoint.path
+        path = each.value.endpoint_path
       }
 
       uri_override_enforce_mode = "ALWAYS"
@@ -70,11 +81,11 @@ resource "google_cloud_tasks_queue" "queues" {
   }
 
   retry_config {
-    max_attempts       = try(each.value.retryPolicy.maxAttempts, -1)
-    max_retry_duration = try(each.value.retryPolicy.maxRetryDuration, "0s")
-    min_backoff        = try(each.value.retryPolicy.minBackoff, "1s")
-    max_backoff        = try(each.value.retryPolicy.maxBackoff, "60s")
-    max_doublings      = try(each.value.retryPolicy.maxDoublings, 16)
+    max_attempts       = each.value.max_attempts
+    max_retry_duration = each.value.max_retry_duration
+    min_backoff        = each.value.min_backoff
+    max_backoff        = each.value.max_backoff
+    max_doublings      = each.value.max_doublings
   }
 
   stackdriver_logging_config {


### PR DESCRIPTION
Triggers defined in `serviceContainer.triggers` (or the `triggers` variable) can now carry a generic `enabled` boolean. When a trigger sets `enabled: false`, it is filtered out before any infrastructure is generated, so no resources are created for it regardless of its type (Pub/Sub, Cloud Tasks, Eventarc, or cron). Triggers without the field continue to be enabled by default, so existing configurations are unaffected.