### PR TITLE
✨ Limit spurious diffs caused by console and CLI deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Features:
 
 - Support the `enabled` boolean on any trigger. When set to `false`, the trigger is paused where its resource supports it (Cloud Tasks queues via `desired_state`, Cloud Scheduler jobs via `paused`) and removed otherwise (Pub/Sub, Eventarc).
 
+Fixes:
+
+- Avoid spurious diffs on the Cloud Run service caused by console or CLI deployments, by ignoring changes to the `client` and `client_version` attributes and setting a fixed container name.
+
 ## v0.24.0 (2026-05-19)
 
 Breaking changes:

--- a/service.tf
+++ b/service.tf
@@ -27,6 +27,7 @@ resource "google_cloud_run_v2_service" "service" {
 
   template {
     containers {
+      name  = "service"
       image = local.image
 
       resources {
@@ -123,4 +124,11 @@ resource "google_cloud_run_v2_service" "service" {
     google_secret_manager_secret_iam_member.service_secrets,
     google_project_iam_member.service_monitoring_metric_writer,
   ]
+
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+    ]
+  }
 }


### PR DESCRIPTION
Deployments made outside of Terraform — through the Google Cloud console or the `gcloud` CLI — stamp the Cloud Run service with their own `client` and `client_version` metadata and auto-assign a container name. These values then show up as drift on the next Terraform plan even though nothing meaningful changed.

The Cloud Run service now ignores changes to `client` and `client_version`, and pins the container to a fixed name, so plans stay clean regardless of how the service was last deployed.

The first apply after upgrading may show a one-time in-place update setting the container name on services that were previously deployed with an auto-assigned one.