### PR TITLE
🐛 Pass Cloud Run timeout as a duration string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Pass the Cloud Run service `timeout` to Terraform as a duration string (`<seconds>s`) rather than a bare number.
+
 ## v1.0.0 (2026-06-12)
 
 Features:

--- a/service.tf
+++ b/service.tf
@@ -96,7 +96,7 @@ resource "google_cloud_run_v2_service" "service" {
       }
     }
 
-    timeout                          = local.timeout
+    timeout                          = local.timeout != null ? "${local.timeout}s" : null
     max_instance_request_concurrency = local.request_concurrency
     service_account                  = local.service_account_email
 


### PR DESCRIPTION
The Cloud Run service `timeout` was passed to the `google_cloud_run_v2_service` resource as a bare number of seconds, whereas the provider expects a duration string (e.g. `300s`). This could lead to the value being rejected or misinterpreted by the provider. The timeout is now formatted as `<seconds>s` before being passed to Terraform, while the configuration and variable remain expressed in seconds. A `null` timeout is preserved so the provider default still applies when no value is set.