### PR TITLE
✨ Add the service_account_email output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Add the `service_account_email` output, exposing the email of the service account used by the Cloud Run service.
+
 ## v1.0.1 (2026-06-26)
 
 Fixes:

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "url" {
   description = "The URL to make requests to the Cloud Run service."
 }
 
+output "service_account_email" {
+  value       = local.service_account_email
+  description = "The email of the service account used by the Cloud Run service."
+}
+
 output "public_http_endpoints" {
   description = "The list of public HTTP endpoints (routes) for the service."
   value       = var.enable_public_http_endpoints ? local.conf_http_endpoints : []


### PR DESCRIPTION
The module now exposes the email of the service account used by the Cloud Run service through the new `service_account_email` output. This makes it possible for callers to grant additional IAM permissions to the service, or reference its identity in resources managed outside of the module, without having to duplicate the account naming logic.

The output is set whether the service account is created by the module or provided through the `service_account` variable.